### PR TITLE
Fixemultiuser dreamplex enigma2 plugin

### DIFF
--- a/src/DP_Users.py
+++ b/src/DP_Users.py
@@ -81,7 +81,7 @@ class DPS_Users(Screen):
 		self.guiElements = getGuiElements()
 		self.plexInstance = plexInstance
 
-		self.location = config.plugins.dreamplex.configfolderpath.value + "homeUsers"
+		self.location = config.plugins.dreamplex.configfolderpath.value + "homeUsers/users.xml"
 
 		checkXmlFile(self.location)
 
@@ -301,7 +301,7 @@ class DPS_UsersEntryList(MenuList):
 		self.l.setFont(0, gFont("Regular", 20))
 		self.l.setFont(1, gFont("Regular", 18))
 
-		self.location = config.plugins.dreamplex.configfolderpath.value + "homeUsers"
+		self.location = config.plugins.dreamplex.configfolderpath.value + "homeUsers/users.xml"
 
 		printl("", self, "C")
 


### PR DESCRIPTION
A simple patch to DP_User.py class to fix the wrong path of the users.xml settings file that cause enigma2 crash.